### PR TITLE
Fixed syntax errors in schema.sql, added create database if not exist statement and removed superfluous SELECT statements.

### DIFF
--- a/srv/schema.sql
+++ b/srv/schema.sql
@@ -7,6 +7,7 @@ DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS sessions;
 DROP TABLE IF EXISTS recipes;
 DROP TABLE IF EXISTS users_recipes;
+DROP TABLE IF EXISTS users_recipes_stars;
 
 CREATE TABLE users (
     user_id int(11) NOT NULL AUTO_INCREMENT,

--- a/srv/schema.sql
+++ b/srv/schema.sql
@@ -1,6 +1,8 @@
 -- Initialize the database.
 -- Drop any existing data and create empty tables.
 
+CREATE DATABASE IF NOT EXISTS przepisy;
+
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS sessions;
 DROP TABLE IF EXISTS recipes;
@@ -40,37 +42,10 @@ CREATE TABLE recipes (
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 CREATE TABLE users_recipes_stars (
-	user_id int(11) NOT NULL,
+    user_id int(11) NOT NULL,
     recipe_id int(11) NOT NULL,
     favorite boolean,
     stars int(1),
     FOREIGN KEY (user_id) REFERENCES users(user_id),
     FOREIGN KEY (recipe_id) REFERENCES recipes(recipe_id)
-)ENGINE=MyISAM AUTO DEFAULT CHARSET=utf8;
-
-SELECT R.recipe_name AS Recipe, U.user_login AS User, count(URS.favorite) AS Favorite, ROUND(avg(URS.stars),0) AS Stars, R.recipe_main_picture as Picture, R.date_time as Date
-    FROM recipes AS R
-    INNER JOIN users AS U
-    ON R.user_id = U.user_id
-    INNER JOIN users_recipes_stars AS URS
-    ON R.recipe_id = URS.recipe_id
-    GROUP BY R.recipe_id
-    ORDER BY R.recipe_name;
-
-SELECT R.recipe_name AS Recipe, U.user_login AS User, count(URS.favorite) AS Favorite, ROUND(avg(URS.stars),0) AS Stars, R.recipe_main_picture as Picture, R.date_time as Date
-    FROM recipes AS R
-    INNER JOIN users AS U
-    ON R.user_id = U.user_id
-    INNER JOIN users_recipes_stars AS URS
-    ON R.recipe_id = URS.recipe_id
-    GROUP BY R.recipe_id
-    ORDER BY R.date_time;
-
-SELECT R.recipe_name AS Recipe, U.user_login AS User, count(URS.favorite) AS Favorite, ROUND(avg(URS.stars),0) AS Stars, R.recipe_main_picture as Picture, R.date_time as Date
-    FROM recipes AS R
-    INNER JOIN users AS U
-    ON R.user_id = U.user_id
-    INNER JOIN users_recipes_stars AS URS
-    ON R.recipe_id = URS.recipe_id
-    GROUP BY R.recipe_id
-    ORDER BY ROUND(avg(URS.stars),0) DESC;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;


### PR DESCRIPTION
There was a syntax error in `users_recipes_stars` table creation statement:

```
CREATE TABLE users_recipes_stars (
	user_id int(11) NOT NULL,
    recipe_id int(11) NOT NULL,
    favorite boolean,
    stars int(1),
    FOREIGN KEY (user_id) REFERENCES users(user_id),
    FOREIGN KEY (recipe_id) REFERENCES recipes(recipe_id)
)ENGINE=MyISAM AUTO DEFAULT CHARSET=utf8;
```

Specifically the very last clausule was wrongly stated:

```
)ENGINE=MyISAM AUTO DEFAULT CHARSET=utf8;
```

The keyword *`AUTO`* previously belonged to `AUTO_INCREMENT` property of the primary key, but was left mistakenly here after removing suffix `_INCREMENT` resulting in erroneous SQL syntax.